### PR TITLE
fix(epub): fall back to cover-named container entries

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -477,6 +477,7 @@ const getImageMediaType = (path) => {
         'png': 'image/png',
         'gif': 'image/gif',
         'webp': 'image/webp',
+        'svg': 'image/svg+xml',
     }
     return mediaTypeMap[extension] || 'image/jpeg'
 }
@@ -490,6 +491,19 @@ const getFontMediaType = (path) => {
         'otf': 'font/otf',
     }
     return mediaTypeMap[extension] || 'font/ttf'
+}
+
+// Container entry whose file name ends in `cover`/`couv` (the French
+// spelling) plus an image extension, e.g. `cover.jpg`, `Images/Cover.PNG`,
+// `couv.jpeg`. Same shape `gnome-epub-thumbnailer` falls back to.
+const UNDECLARED_COVER_RE = /(?:cover|couv)\.(?:jpe?g|png|gif|webp|svg)$/i
+
+// Last-ditch cover lookup for EPUBs where the manifest resolves to nothing:
+// scan the container's own file names. `names` is iterated in central
+// directory order, so the first match wins.
+const findUndeclaredCover = names => {
+    for (const name of names) if (UNDECLARED_COVER_RE.test(name)) return name
+    return null
 }
 
 class MediaOverlay extends EventTarget {
@@ -1275,9 +1289,17 @@ ${doc.querySelector('parsererror').innerText}`)
     }
     async getCover() {
         const cover = this.resources?.cover
-        return cover?.href
-            ? new Blob([await this.loadBlob(cover.href)], { type: cover.mediaType })
-            : null
+        if (cover?.href) return new Blob([await this.loadBlob(cover.href)],
+            { type: cover.mediaType })
+        // Fall back to a cover-named container entry. Some EPUBs ship the
+        // cover image without ever declaring it (no `cover-image` property,
+        // no `<meta name="cover">` target, no manifest item), which leaves
+        // every manifest-driven lookup above empty even though the image is
+        // sitting right there in the zip.
+        const href = findUndeclaredCover(this.entries.keys())
+        if (!href) return null
+        const blob = await this.loadBlob(href)
+        return blob ? new Blob([blob], { type: getImageMediaType(href) }) : null
     }
     async getCalibreBookmarks() {
         const txt = await this.loadText('META-INF/calibre_bookmarks.txt')


### PR DESCRIPTION
Fixes the foliate-js half of readest/readest#5273.

## Problem

Some EPUBs ship the cover image without ever declaring it: no `properties="cover-image"` item, no `<meta name="cover">` target, and no manifest entry at all. The reporter's Calibre-produced sample has `cover.jpg` sitting in the container and `<meta name="cover" content="cover"/>` in the OPF, but the manifest only lists the spine document and the NCX:

```xml
<manifest>
  <item href="start.xhtml" id="start" media-type="application/xhtml+xml"/>
  <item href="toc.ncx" id="ncx" media-type="application/x-dtbncx+xml"/>
</manifest>
```

Every lookup in `Resources` is manifest-driven — including the `href.includes('cover')` heuristic and the first-image-in-manifest last resort — so `getCover()` returns `null` even though the image is right there in the zip. Other readers (`gnome-epub-thumbnailer`, for one) find it.

## Change

When manifest resolution yields nothing, scan the container's own file names for one ending in `cover`/`couv` (the French spelling) plus an image extension. That is the same fallback `gnome-epub-thumbnailer` uses, extended with `webp`. Entries are iterated in central-directory order, so the first match wins.

The fallback lives in `EPUB.getCover()` rather than `Resources` because only `EPUB` holds the entry map, and it runs strictly after every existing manifest path — no behaviour changes for EPUBs that declare a cover.

Also maps `.svg` in `getImageMediaType`, so an SVG-only fallback cover reports `image/svg+xml` instead of `image/jpeg`.