### PR TITLE
fix(paginator): letterbox duokan fullscreen covers instead of stretching

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -938,10 +938,10 @@ class View {
                     width: '100%',
                     height: '100%',
                     margin: '0',
-                    // stretch edge-to-edge, ignoring aspect ratio, so the cover
-                    // fills the whole page like Duokan's native full-page render
-                    // (overrides the 'contain' set for all images above)
-                    'object-fit': 'fill',
+                    // fit the whole page while keeping the aspect ratio
+                    // ('contain' set for all images above); black bars fill
+                    // the leftover space like Duokan's native full-page render
+                    'background-color': '#000',
                 })
                 let ancestor = el.parentElement
                 while (ancestor && ancestor !== doc.body) {
@@ -950,11 +950,13 @@ class View {
                         height: '100%',
                         margin: '0',
                         padding: '0',
+                        // a positioned wrapper (e.g. from duokan-bleed handling)
+                        // would become the containing block for the pinned image,
+                        // whose height:100% then resolves against the wrapper's
+                        // zero height and the cover vanishes (#5263)
+                        position: 'static',
                     })
                     ancestor = ancestor.parentElement
-                }
-                if (el.localName === 'svg') {
-                    el.setAttribute('preserveAspectRatio', 'none')
                 }
             } else if (pageFullscreen) {
                 // Scrolled mode for a fullscreen-cover doc: undo any absolute
@@ -964,12 +966,12 @@ class View {
                 // the stale position:absolute/height:100% and the cover stays
                 // collapsed.
                 doc.documentElement.style.removeProperty('position')
-                for (const prop of ['position', 'inset', 'width', 'height', 'margin']) {
+                for (const prop of ['position', 'inset', 'width', 'height', 'margin', 'background-color']) {
                     el.style.removeProperty(prop)
                 }
                 let ancestor = el.parentElement
                 while (ancestor && ancestor !== doc.body) {
-                    for (const prop of ['width', 'height', 'margin', 'padding']) {
+                    for (const prop of ['width', 'height', 'margin', 'padding', 'position']) {
                         ancestor.style.removeProperty(prop)
                     }
                     ancestor = ancestor.parentElement


### PR DESCRIPTION
## Summary

Three fixes to the `duokan-page-fullscreen` cover handling, all reported in readest/readest#5263:

- **Keep the original aspect ratio.** The fullscreen branch stretched the cover edge-to-edge with `object-fit: fill` (and `preserveAspectRatio: none` for SVG), distorting any cover whose aspect ratio differs from the page. Duokan Reader itself fits the cover and fills the leftover space with black bars, so the pinned element now keeps the `object-fit: contain` applied to all images and paints its background black to letterbox the page the same way.
- **Do not let a positioned wrapper swallow the cover.** Some books end up with a positioned wrapper around the cover image (e.g. Readest's `duokan-bleed` CSS handling adds `position: relative` to it). The absolutely pinned image then resolves `height: 100%` against the wrapper, whose height chains through a zero-height body, and the cover page renders completely blank. Intermediate ancestors are now forced to `position: static` so the image always pins to the page root.
- **Seed scroll bounds when the restore anchor has no client rects.** Restoring a saved position at such a cover resolves the CFI to a range whose end boundary sits inside the pinned image; the range has no in-flow boxes and `getClientRects()` is empty, so `#scrollToAnchor` bailed without scrolling. `#scrollBounds` then stayed unseeded and the `scrollBy`/`snap` guards silently dropped every swipe on the page ("cannot swipe to paginate on the cover") until some other navigation seeded them. Both the rect-less bail and the sibling zero-`contentPages` bail now settle on the primary section's start instead.

The scrolled-mode cleanup path removes the new `background-color`/`position` styles when toggling out of paginated mode.

## Testing

Covered by the duokan-cover browser tests in readest-app (updated alongside the submodule bump). The rendering fixes were verified against both books attached to readest/readest#5263 on web and Android; the swipe fix was root-caused with on-device instrumentation and verified by finger on a Xiaomi (Android) with the reporter's book: cold-open at the cover now paginates on the first swipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)