### PR TITLE
fix(paginator): seed scroll bounds when the anchor has no client rects

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -3085,7 +3085,15 @@ export class Paginator extends HTMLElement {
             // previous column, there is an extra zero width rect in that column
             const rect = Array.from(rects)
                 .find(r => r.width > 0 && r.height > 0 && r.x >= 0 && r.y >= 0) || rects[0]
-            if (!rect) return
+            // An anchor can have no client rects at all: a range over content
+            // that is entirely absolutely positioned (e.g. a Duokan fullscreen
+            // cover pins its only image) has no in-flow boxes. Bailing without
+            // scrolling would leave #scrollBounds unseeded, and scrollBy/snap
+            // then silently drop every swipe on the page (#5263). Settle on
+            // the primary section's start instead.
+            if (!rect) return this.scrolled
+                ? this.#scrollTo(this.#getViewOffset(this.#primaryIndex), reason)
+                : this.#scrollToPage(this.#getPagesBeforeView(this.#primaryIndex), reason)
             await this.#scrollToRect(rect, reason)
             // focus the element when navigating with keyboard or screen reader
             if (reason === 'navigation') {
@@ -3119,7 +3127,9 @@ export class Paginator extends HTMLElement {
         if (!primaryView) return
         const pagesBeforePrimary = this.#getPagesBeforeView(this.#primaryIndex)
         const textPages = primaryView.contentPages
-        if (!textPages) return
+        // Same as the rect-less bail above: a section that measured zero
+        // content pages must still settle so #scrollBounds gets seeded.
+        if (!textPages) return this.#scrollToPage(pagesBeforePrimary, reason)
         // textPages is in column units; convert to spread page for scrolling
         const newColumn = Math.round(anchor * (textPages - 1))
         const newSpreadPage = Math.floor(newColumn / this.columnCount)


### PR DESCRIPTION
## Summary

Follow-up to #63, which was merged before this commit reached its branch — this is the swipe half of readest/readest#5263.

Restoring a saved position at a duokan fullscreen cover resolves the CFI to a range whose end boundary sits inside the pinned cover image. Such a range has no in-flow boxes and `getClientRects()` returns an empty list, so `#scrollToAnchor` bailed without scrolling. `#scrollBounds` then stayed unseeded and the `scrollBy`/`snap` guards silently dropped every swipe on the page until some other navigation seeded it — swipe-to-paginate read as dead on the first page of these books after opening.

Fall back to settling on the primary section's start instead of bailing, both for rect-less anchors and for the sibling zero-`contentPages` case, so every completed anchor scroll leaves the pager in a swipeable state.

## Testing

Root-caused with on-device instrumentation (finger trace: touchstart with unseeded bounds, every `scrollBy`/`snap` bailing) and verified by finger on a Xiaomi device with the reporter's book: cold-open at the cover now paginates on the first swipe. Browser suite in readest-app passes (336).

Fixes readest/readest#5263 (together with #63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)