### PR TITLE
fix(opds): prefer issued publication date

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -216,8 +216,8 @@ export const getPublication = entry => {
             author: children.filter(filter('author')).map(getPerson),
             contributor: children.filter(filter('contributor')).map(getPerson),
             publisher: children.find(filterDC('publisher'))?.textContent ?? undefined,
-            published: (children.find(filter('published'))
-                ?? children.find(filterDCTERMS('issued'))
+            published: (children.find(filterDCTERMS('issued'))
+                ?? children.find(filter('published'))
                 ?? children.find(filterDC('date')))?.textContent ?? undefined,
             language: children.find(filterDC('language'))?.textContent ?? undefined,
             identifier: children.find(filterDC('identifier'))?.textContent ?? undefined,


### PR DESCRIPTION
## Problem

Some OPDS entries contain both Atom `<published>` and Dublin Core `<dcterms:issued>` values. Calibre-based catalogs may use `<published>` for the date a book entered the catalog while `<dcterms:issued>` contains the book's publication date.

The parser currently chooses `<published>` first, causing clients to display the catalog date as the book's publication date.

## Change

Prefer `<dcterms:issued>` when present. Keep Atom `<published>` and Dublin Core `<dc:date>` as fallbacks.

## Verification

- ESLint 9.28.0, matching the repository workflow: 0 errors
- Verified against a Calibre OPDS feed containing both fields
- Verified in the Readest web client and Android app