### PR TITLE
feat(tts): let the node filter decide ruby, and never paint annotations

### DIFF
--- a/overlayer.js
+++ b/overlayer.js
@@ -87,6 +87,14 @@ export class Overlayer {
             NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, {
                 acceptNode: node => {
                     if (!range.intersectsNode(node)) return NodeFilter.FILTER_REJECT
+                    // Ruby annotations sit on their own line above (or beside)
+                    // the base, so their rects would draw a second detached box
+                    // over the furigana. Never paint them — not the book's own
+                    // ruby, not injected glosses.
+                    const el = node.nodeType === Node.TEXT_NODE
+                        ? node.parentElement : node
+                    if (el?.closest?.('rt, rp, rtc, [cfi-inert]'))
+                        return NodeFilter.FILTER_REJECT
                     if (node.nodeType === Node.TEXT_NODE) return NodeFilter.FILTER_ACCEPT
                     return node.matches?.('img, svg')
                         ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP

--- a/tts.js
+++ b/tts.js
@@ -70,8 +70,16 @@ const fragmentToSSML = (fragment, nodeFilter, inherited) => {
 
     const convert = (node, parent, inheritedAlphabet) => {
         if (!node) return
-        if (node.nodeType === 3) return ssml.createTextNode(node.textContent)
-        if (node.nodeType === 4) return ssml.createCDATASection(node.textContent)
+        // Text nodes go through the filter too: the text walker that produces
+        // the marks already honours it, and content that is skipped there (a
+        // bare ruby base inside <ruby>, say) must not reach the speech either,
+        // or the two disagree about what is being read.
+        if (node.nodeType === 3 || node.nodeType === 4) {
+            if (nodeFilter && nodeFilter(node) === NodeFilter.FILTER_REJECT) return
+            return node.nodeType === 3
+                ? ssml.createTextNode(node.textContent)
+                : ssml.createCDATASection(node.textContent)
+        }
         if (node.nodeType !== 1 && node.nodeType !== 11) return
         if (nodeFilter && nodeFilter(node) === NodeFilter.FILTER_REJECT) return
 


### PR DESCRIPTION
Support for speaking Japanese furigana readings instead of the base kanji in Readest (readest/readest#5539). Callers select the behaviour through the node filter they already pass in; these two changes make that possible.

### `fragmentToSSML` filters text nodes

The filter was applied to elements only. A group-ruby base is a bare text child of `<ruby>` with no `<rb>` wrapper:

```html
<ruby>数多<rt>あまた</rt></ruby>
```

so a filter that skips the base still saw it reach the speech — the text walker producing the marks had dropped it, and the two ended up disagreeing about what was being read (`数多あまたの星` instead of `あまたの星`). Text nodes now go through the same filter. Every existing filter accepts them, so this is a no-op for current callers.

### `Overlayer` never collects rects from ruby annotations

`#splitRange` walked into `<rt>`. Furigana renders on its own line above (or beside) the base, so its rects drew a second detached box floating over the annotation instead of on the text it covers. `rt`, `rp`, `rtc` and injected `[cfi-inert]` content are now skipped. When the split yields nothing the existing whole-range fallback still applies, so a selection made entirely inside an annotation is not silently invisible.

### Testing

Both changes are covered by tests in the Readest tree that fail without them (`document/tts.test.ts`, `document/overlayer-highlight-blocks.test.ts`). Verified in Chrome against a Japanese EPUB covering group ruby, `<rb>` bases, interleaved mono pairs, empty `<rt>` okurigana padding, `<rp>` parentheses, gaiji `<img>` bases and emphasis dots.