### PR TITLE
fix(view): keep the cursor visible while text is selected

### DIFF
--- a/view.js
+++ b/view.js
@@ -146,7 +146,15 @@ class CursorAutohider {
     cloneFor(el) {
         return new CursorAutohider(el, this.#check, this.#state)
     }
+    #hasSelection() {
+        const selection = this.#el.ownerDocument?.getSelection()
+        return selection ? !selection.isCollapsed : false
+    }
     hide() {
+        // The pointer is what the reader aims a selection with, so leave it
+        // alone while one stands: a paused drag, or a double-click word
+        // select (which fires no mousemove at all), would otherwise blank it.
+        if (this.#hasSelection()) return
         this.#el.style.cursor = 'none'
         this.#state.hidden = true
     }


### PR DESCRIPTION
## Problem

`CursorAutohider` decides purely on mousemove idleness: any pointer that sits still for 1s gets `cursor: none`. It has no notion of an active text selection, so it blanks the cursor exactly when the reader is still aiming with it:

- a **paused selection drag** (you stop to think about where to end the selection, the cursor vanishes), and
- a **double-click word select**, which fires no `mousemove` at all, so the already armed timer just runs and hides the pointer on a fresh selection.

## Fix

Skip hiding while the element's document holds a non-collapsed selection.

The guard lives in `hide()` rather than at arm time, which is what makes it cover both cases: a selection created *after* the timer was armed (double-click) as well as the timer re-armed *while* a selection stands (paused drag).

`ownerDocument` resolves to the right scope for either instance: the top document for the host `<foliate-view>`, and the section's iframe document for the per-section clone created in `#onLoad` via `cloneFor(doc.documentElement)`, which is where reader selections actually live.

## Notes

No stuck-visible state: autohide resumes as soon as the selection collapses, which any click does, and the next mousemove re-arms the timer.

Consumer-side tests live in readest (`src/__tests__/reader/autohide-cursor.test.ts`), which drives this class through the real custom element. Both new cases were confirmed failing against the old code before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)