### PR TITLE
fix: restore U+200F/U+200E BiDi marks after XMLSerializer in epub.js

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1048,10 +1048,14 @@ class Loader {
                 el.setAttribute('style',
                     await this.replaceCSS(el.getAttribute('style'), href, parents))
             // TODO: replace inline scripts? probably not worth the trouble
-            const result = new XMLSerializer().serializeToString(doc)
+            const serialized = new XMLSerializer().serializeToString(doc)
+            // Restore BiDi control characters that XMLSerializer encodes as
+            // numeric character references, which breaks Persian/Arabic text shaping.
+            const result = serialized
+                .replaceAll('&#x200e;', '\u200E').replaceAll('&#8206;', '\u200E')
+                .replaceAll('&#x200f;', '\u200F').replaceAll('&#8207;', '\u200F')
             return this.createURL(href, result, item.mediaType, parent)
         }
-
         const result = mediaType === MIME.CSS
             ? await this.replaceCSS(str, href, parents)
             : await this.replaceString(str, href, parents)


### PR DESCRIPTION
 ## Problem

Persian and Arabic ebooks that use U+200F (RIGHT-TO-LEFT MARK) inside words render as broken/garbled text in Readest. The root cause is that `XMLSerializer.serializeToString()` in `Loader.loadReplaced()` (epub.js line 1051) encodes these BiDi control characters as numeric character references (`&#x200f;`, `&#8207;`, etc.) before the content is stored as a blob URL. The font shaper then sees an XML entity instead of the literal character and cannot apply correct joining/ligature behaviour to the surrounding Persian letters.

Reported in readest/readest#5216.

## Fix

Restore U+200E (LRM) and U+200F (RLM) — in both hex and decimal entity forms — back to their literal characters immediately after serialization, before `createURL()` stores the result. This mirrors the same fix already applied in the readest app's sanitizer transformer as a downstream safety net.

## Testing

Open a Persian or Arabic EPUB containing words with U+200F Text should render with correct letter joining, matching the behaviour of other readers such as Moon+ Reader.