### PR TITLE
fix(epub): retry a malformed XHTML section as HTML in loadDocument

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1261,7 +1261,16 @@ ${doc.querySelector('parsererror').innerText}`)
     }
     async loadDocument(item) {
         const str = await this.loadText(item.href)
-        return this.parser.parseFromString(str, item.mediaType)
+        const doc = this.parser.parseFromString(str, item.mediaType)
+        // Same fallback as the render path in `loadReplaced`: a file the
+        // manifest declares as XHTML but which isn't well-formed XML (an
+        // unclosed `<meta charset>` is the usual culprit) parses into a
+        // `parsererror` document whose `body` is null. Callers of
+        // `createDocument` walk that body, so retry as HTML instead.
+        if (item.mediaType === MIME.XHTML
+        && (doc.querySelector('parsererror') || !doc.documentElement?.namespaceURI))
+            return this.parser.parseFromString(str, MIME.HTML)
+        return doc
     }
     getMediaOverlay() {
         return new MediaOverlay(this, this.#loadXML.bind(this))


### PR DESCRIPTION
## Problem

A manifest can declare a section as `application/xhtml+xml` while the file is not well-formed XML. Adobe InDesign and Digital Editions ship an unclosed `<meta charset="utf-8">` constantly. The XML parser then hands back a `parsererror` document whose `body` is **null**.

The render path already recovers from this. `loadReplaced` reparses as `text/html` when it sees a `parsererror` or a namespace-less root:

```js
if (mediaType === MIME.XHTML && (doc.querySelector('parsererror')
|| !doc.documentElement?.namespaceURI)) {
    item.mediaType = MIME.HTML
    doc = new DOMParser().parseFromString(str, item.mediaType)
}
```

`loadDocument`, which backs `Section.createDocument()`, did not, so every off-screen consumer got the error document instead of the chapter.

## Impact

Readest converts KOReader CREngine XPointers through `createDocument()` whenever the target section is not the rendered one, and walks `document.body.children` to resolve the path. Against a body-less error document that threw:

```
TypeError: Cannot read properties of null (reading 'children')
```

which silently killed cross-device reading progress sync.

## Fix

Apply the same fallback in `loadDocument`.

## Verification

Confirmed in real Chromium and WebKit (via Playwright) that for such a file `doc.body === null` and `doc.querySelector('parsererror')` matches, so the same test `loadReplaced` uses is the right one here. Covered by a regression test in the Readest repo (`foliate-epub-malformed-xhtml.test.ts`) that builds an EPUB with a malformed chapter and asserts both `createDocument()` and the full XPointer conversion; it reproduces the `TypeError` verbatim without this change.

Refs: readest/readest#5625