### PR TITLE
fix(paginator): re-apply the settled scroll offset when WebKit clamps it

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -87,6 +87,24 @@ const cssAnimateScroll = (element, scrollProp, startValue, endValue, duration, e
 
         // Apply final scroll position
         element[scrollProp] = endValue
+        // Translating the children shrank the container's scrollable overflow
+        // by the animated distance, and WebKit (iOS 18) still reports that
+        // shrunken extent when the transforms are cleared in this same task —
+        // so the assignment above is clamped. Mid-book the clamp lands far
+        // beyond the target and is invisible; on the last page of the book,
+        // where the target *is* the maximum scroll offset, it lands a full page
+        // short and the page visibly snaps back (readest#5663).
+        if (Math.abs(element[scrollProp] - endValue) > 0.5) {
+            // Forcing a layout here is not enough — the extent it reports is
+            // restored, but the scroll clamp still uses the stale one for the
+            // rest of the task. The next frame is past the compositor's
+            // animation teardown, so re-apply there.
+            requestAnimationFrame(() => {
+                element[scrollProp] = endValue
+                resolve()
+            })
+            return
+        }
         resolve()
     }
 


### PR DESCRIPTION
`cssAnimateScroll` turns a page by putting `transform: translateX(-delta)` on every view element, then in its cleanup clears the transforms and immediately assigns the final scroll offset.

Translating the children shrinks the container's scrollable overflow by the animated distance, and WebKit on iOS 18 keeps clamping against that shrunken extent for the rest of the task, so the assignment lands short.

Mid-book the clamp sits far beyond the target and is invisible. On the **last page of the book**, where the target is exactly the maximum scroll offset, it lands a full page short and the page visibly snaps back, so the final page of long books cannot be reached at all.

Device trace from the failing turn (iPhone XR / iOS 18.5):

```
next     {"pages":305,"size":414,"rvs":126270,"sw":126270,"cw":414,"max":125856,"tgt":125856}
css-done {"req":125856,"act":125442,"max":125442,"rvs":126270}
```

`max` drops by exactly one page (414px) between issuing the turn and applying it, while the summed view widths (`rvs`) are unchanged.

Forcing a layout first is not enough: the extent it reports is restored, but the scroll clamp still uses the stale one for the rest of the task, measured on device:

```
clamp-retry {"end":125856,"after":125445,"sw":125859}   <- forced layout, still clamped
clamp-raf   {"end":125856,"after":125856}               <- next frame, lands
```

So the fix detects the short landing and re-applies on the next frame, which is past the compositor's animation teardown.

### Verification

Verified on an iPhone XR / iOS 18.5 simulator with the EPUB from readest/readest#5663, reading straight through the book:

- before: stuck on chapter 10's last page (`3/4`, 276/277)
- after: reaches the final section, footer reads 277/277

Exactly one clamp event occurs in a 309-turn run, at the last page. Not reproducible on iOS 26.3, and not on other engines: every non-iOS platform takes the `rafAnimateScroll` path for a book that size, which writes the scroll offset directly each frame and never uses transforms.
