### PR TITLE
feat(paginator): expose a sub-pixel scroll offset for slow continuous scrolling

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1298,6 +1298,7 @@ export class Paginator extends HTMLElement {
     #touchScrolled
     #lastVisibleRange
     #scrollLocked = false
+    #subpixelOffset = 0
     #isAnimating = false
     // Generation counter for slideTurnAnimation: a newer vertical page turn
     // bumps it so an in-flight two-phase slide stops touching the DOM.
@@ -2142,6 +2143,31 @@ export class Paginator extends HTMLElement {
     }
     set containerPosition(newVal) {
         this.#container[this.scrollProp] = newVal
+    }
+    // Scroll offsets quantize to whole CSS pixels in both Blink and WebKit
+    // (`scrollTop = 100.5` reads back 100 or 101), so a slow continuous scroll
+    // such as Auto Scroll advances in visible one-pixel steps: at 5px/s that is
+    // one jump every 200ms. The whole pixels stay in the scroll position, which
+    // everything else reads; this carries only the sub-pixel remainder, as a
+    // composited transform on the scrollport itself.
+    //
+    // The transform goes on #container rather than its children on purpose: a
+    // transform on the children shifts their border boxes and shrinks the
+    // container's scrollable overflow, which desynchronizes the scroll math
+    // (readest#5663). Transforming the scrollport moves it as a whole and
+    // leaves its scrollable overflow untouched.
+    get subpixelOffset() {
+        return this.#subpixelOffset
+    }
+    set subpixelOffset(offset) {
+        const value = Number.isFinite(offset) ? offset : 0
+        if (value === this.#subpixelOffset) return
+        this.#subpixelOffset = value
+        // Scrolling forward by `value` moves the content back by the same
+        // amount. Vertical writing pages along the inline axis in scrolled mode.
+        const axis = this.scrollProp === 'scrollLeft' ? 'X' : 'Y'
+        this.#container.style.transform = value
+            ? `translate${axis}(${-value}px) translateZ(0)` : ''
     }
     get scrollLocked() {
         return this.#scrollLocked


### PR DESCRIPTION
Scroll offsets quantize to whole CSS pixels in both engines, measured at dpr 2:

| | `scrollTop = 100.5` reads back | min rendered step |
|---|---|---|
| Chromium | 101 | 1 CSS px |
| WebKit (desktop and iOS 18.5) | 100 | 1 CSS px |

A read-modify-write of `+0.1` per frame never moves at all, which is why callers must carry the fraction themselves. But even with the fraction carried, the smallest thing a scroll offset can render is a whole pixel, so a slow continuous scroll steps visibly. Readest's Auto Scroll runs as slow as 5px/s, which is one 1px jump every 200ms rather than a glide.

`subpixelOffset` keeps the whole pixels in the scroll position, which everything else reads (progress, relocate, preloading, annotations), and carries only the remainder, always under one pixel, as a composited transform.

The transform goes on `#container` rather than its children on purpose: a transform on the children shifts their border boxes and shrinks the container's scrollable overflow, which desynchronizes the scroll math and is exactly what caused #73 / readest/readest#5663. Transforming the scrollport moves it as a whole and leaves its scrollable overflow untouched. It also preserves `translateZ(0)` so the scrolled-mode layer promotion is unchanged.

### What each engine actually renders

Measured on rasterized pixels rather than geometry: a black bar moved in ten 0.1px steps, with the intensity weighted centroid of its antialiased edge recovered from screenshots.

| engine | frames that moved | step size |
|---|---|---|
| WebKit (iOS 18.5, macOS) | 10 / 10 | ~0.2 device px, continuous |
| Chromium | 2 / 10 | 1 device px |

WebKit becomes fully continuous. **Blink still snaps composited layers to whole device pixels**, so it improves from a 1 CSS px step to a 1 device px step (2x finer at dpr 2, ~3x at dpr 3) rather than becoming smooth. The snap is not a matter of transform syntax: `translateY`, `translateY + translateZ(0)` and `translate3d` all give identical results in Blink, and a plain `top` offset is worse (2 device px). A compositor driven WAAPI animation does interpolate sub-pixel in Blink, but using it for the remainder needs a scroll resync at every whole pixel, so it is left as a possible follow-up.

The API is engine neutral: the caller sets a sub-pixel offset and each engine renders it as finely as it can.

### Verification

Measured on an iPhone XR / iOS 18.5 simulator, running 5px/s for 2s and recording the on-screen position of a marker every frame:

| | distinct on-screen positions | largest single jump | distance |
|---|---|---|---|
| whole-pixel scroll only | 11 of 122 frames | 1 px | 10 px |
| scroll + sub-pixel transform | 121 of 121 frames | 0.105 px | 10 px |

Same distance travelled, so the speed is unchanged; only the granularity. Also verified end to end in the Readest web app under WebKit: 150 of 150 frames distinct, largest jump 0.52px, and the offset returns to 0 with the inline transform cleared when the session stops.
