### PR TITLE
feat(pdf): read ViewerPreferences Direction as book.dir

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -502,6 +502,12 @@ export const makePDF = async file => {
     const calibreSeries = parseCalibreSeriesFromXMP(metadata?.getRaw?.())
     if (calibreSeries) book.metadata.belongsTo = { series: calibreSeries }
 
+    // PDFs bound right-to-left (Japanese photo books, manga) declare it in the
+    // catalog's ViewerPreferences; surface it as book.dir so the fixed-layout
+    // renderer pairs and orders two-page spreads right-to-left.
+    const viewerPreferences = await pdf.getViewerPreferences().catch(() => null)
+    if (viewerPreferences?.Direction === 'R2L') book.dir = 'rtl'
+
     const outline = await pdf.getOutline()
     book.toc = outline ? await Promise.all(outline.map(item => makeTOCItem(item, pdf))) : null
 


### PR DESCRIPTION
PDFs bound right-to-left (Japanese photo books, manga) declare it in the catalog's ViewerPreferences as `/Direction /R2L`. Surface it as `book.dir` so the fixed-layout renderer pairs and orders two-page spreads right-to-left and page navigation follows the reading direction.

Covered by a browser test in the readest app (`pdf-viewer-preferences-direction.browser.test.ts`) that loads minimal R2L-flagged and unflagged PDFs through `makePDF` and asserts `book.dir`.

Part of readest/readest#5591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)