### PR TITLE
fix(fixed-layout): restore scrolled PDF annotations

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -1152,7 +1152,12 @@ export class FixedLayout extends HTMLElement {
             : (hostWidth / vw) * this.#scaleFactor
 
         if (frame.onZoom) {
-            frame.onZoom({ doc: frame.iframe.contentDocument, scale, pageColors: this.#pageColors })
+            const p = frame.onZoom({
+                doc: frame.iframe.contentDocument,
+                scale,
+                pageColors: this.#pageColors,
+            })
+            if (p?.then) p.then(() => this.#refreshOverlayerForFrame(frame))
             Object.assign(frame.iframe.style, {
                 width: `${vw * scale}px`,
                 height: `${vh * scale}px`,


### PR DESCRIPTION
Fixes the overlay lifecycle for PDF pages in scrolled mode.

The renderer starts the asynchronous `onZoom` work, creates the annotation overlayer, and then PDF.js replaces the text-layer DOM. That leaves saved and synced highlights holding ranges into detached nodes.

Refresh the overlayer after `onZoom` settles so annotations are resolved against the current text layer, matching the existing paginated PDF path.

Related: readest/readest#5586

Verification is covered by a controlled browser regression test in readest/readest#5719.
