### PR TITLE
feat(footnotes): expose extraction CFI mapping on the render event

### DIFF
--- a/epubcfi.js
+++ b/epubcfi.js
@@ -129,14 +129,14 @@ const toInnerString = parsed => parsed.parent
     ? [parsed.parent, parsed.start, parsed.end].map(toInnerString).join(',')
     : parsed.map(parts => parts.map(partToString).join('')).join('!')
 
-const toString = parsed => wrap(toInnerString(parsed))
+export const toString = parsed => wrap(toInnerString(parsed))
 
 export const collapse = (x, toEnd) => typeof x === 'string'
     ? toString(collapse(parse(x), toEnd))
     : x.parent ? concatArrays(x.parent, x[toEnd ? 'end' : 'start']) : x
 
 // create range CFI from two CFIs
-const buildRange = (from, to) => {
+export const buildRange = (from, to) => {
     if (typeof from === 'string') from = parse(from)
     if (typeof to === 'string') to = parse(to)
     from = collapse(from)

--- a/footnotes.js
+++ b/footnotes.js
@@ -1,3 +1,5 @@
+import * as CFI from './epubcfi.js'
+
 const getTypes = el => new Set([
     ...(el?.getAttributeNS?.('http://www.idpf.org/2007/ops', 'type')?.split(' ') ?? []),
     ...(el?.attributes?.getNamedItem?.('epub:type')?.value?.split(' ') ?? []),
@@ -53,6 +55,49 @@ const extractFootnote = (doc, anchor) => {
     return el
 }
 
+const isTextish = node => node?.nodeType === 3 || node?.nodeType === 4
+
+// Describe how an extracted fragment maps back onto the pristine section
+// document, so a CFI computed against the mutated popup document (whose body
+// is replaced with the fragment) can be translated into one that resolves in
+// the original document, and vice versa. Only ranges with element-aligned
+// boundaries in a single container element are supported (which covers every
+// range built below except resolved CFI ranges); anything else returns null.
+//
+// The mapping works because a CFI child step's index depends only on the
+// number of preceding *element* siblings (elements take even indices, text
+// chunks the odd indices between them), so moving a contiguous, chunk-aligned
+// run of children into an empty body shifts every first-level index by a
+// constant `delta` and leaves all deeper steps untouched.
+export const getExtractMapping = range => {
+    try {
+        const container = range.startContainer
+        if (container !== range.endContainer || container.nodeType !== 1) return null
+        const children = Array.from(container.childNodes)
+        // a start boundary that splits a text chunk cannot be mapped: the cut
+        // would change character offsets within the popup's first chunk
+        if (isTextish(children[range.startOffset - 1])
+            && isTextish(children[range.startOffset])) return null
+        const countElements = nodes => nodes.filter(n => n.nodeType === 1).length
+        const delta = 2 * countElements(children.slice(0, range.startOffset))
+        const endElements = 2 * countElements(children.slice(0, range.endOffset))
+        const collapsed = container.ownerDocument.createRange()
+        collapsed.setStart(container, 0)
+        collapsed.collapse(true)
+        return {
+            // collapsed CFI (document part only) of the container element
+            containerCfi: CFI.fromRange(collapsed),
+            delta,
+            // first/last first-level indices (in original-document terms)
+            // covered by the extracted range, for reverse mapping
+            firstIndex: delta + (isTextish(children[range.startOffset]) ? 1 : 2),
+            lastIndex: endElements + (isTextish(children[range.endOffset - 1]) ? 1 : 0),
+        }
+    } catch {
+        return null
+    }
+}
+
 export class FootnoteHandler extends EventTarget {
     detectFootnotes = true
     #showFragment(book, { index, anchor, check }, href) {
@@ -64,6 +109,7 @@ export class FootnoteHandler extends EventTarget {
                     const el = anchor(doc)
                     const type = getReferencedType(el)
                     const hidden = el?.matches?.('aside') && type === 'footnote'
+                    let extract = null
                     if (el) {
                         let range
                         if (el.startContainer) {
@@ -116,11 +162,18 @@ export class FootnoteHandler extends EventTarget {
                                 range.selectNode(el)
                             }
                         }
+                        extract = getExtractMapping(range)
                         const frag = range.extractContents()
                         doc.body.replaceChildren()
                         doc.body.appendChild(frag)
+                    } else {
+                        // no anchor: the popup shows the whole pristine
+                        // section, so the mapping is the identity over body
+                        const r = doc.createRange()
+                        r.selectNodeContents(doc.body)
+                        extract = getExtractMapping(r)
                     }
-                    const detail = { view, href, type, hidden, target: el }
+                    const detail = { view, href, type, hidden, target: el, index, extract }
                     this.dispatchEvent(new CustomEvent('render', { detail }))
                     resolve()
                 } catch (e) {


### PR DESCRIPTION
The footnote popup extracts the note fragment into an empty body (\`extractContents\` + \`body.replaceChildren\`), which destroys CFI parity between the popup document and the pristine section, so a CFI computed against the popup cannot resolve in the original document.

This computes a mapping before extraction and passes it, along with the section index, on the \`render\` event detail so consumers can translate CFIs between the popup document and the original section in both directions:

- \`containerCfi\`: collapsed CFI (document part only) of the range's container element
- \`delta\`: constant shift of every first-level child-step index (2 x the number of container element children preceding the extraction start)
- \`firstIndex\`/\`lastIndex\`: the range of first-level indices the fragment covers, for reverse-mapping bounds

The mapping works because a CFI child step's index depends only on the number of preceding *element* siblings (elements take even indices, text chunks the odd indices between them), so moving a contiguous, chunk-aligned run of children into an empty body shifts every first-level index by a constant and leaves all deeper steps untouched. Only element-aligned boundaries in a single container are supported — which covers every range built by \`#showFragment\` except resolved CFI-range anchors — and anything else yields \`null\`.

Also exports \`toString\` and \`buildRange\` from epubcfi.js for that translation, and \`getExtractMapping\` itself for unit testing.

Used by readest to support the text-selection/annotation toolbar inside footnote popups (readest/readest#5646); round-trip mapping tests live there in \`src/__tests__/utils/footnote-cfi-mapping.test.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)