### PR TITLE
fix(epub): count top-level resource refs so a second view cannot revoke a live section

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -885,6 +885,19 @@ class Loader {
         return url
     }
     ref(href, parent) {
+        // A top-level load -- a view opening a section -- has no parent
+        // document to hang the reference on, and is released by exactly one
+        // `unloadItem`, so it must always be counted. Recording it under an
+        // absent parent instead put every top-level load in the book into one
+        // shared `#children` bucket that nothing ever cleared, so the second
+        // view to open an already-loaded section (a footnote popup, which
+        // opens another view on the same book) skipped its increment yet still
+        // decremented on close. The count underflowed to zero and revoked the
+        // section along with its images while a view was still showing them.
+        if (!parent) {
+            this.#refCount.set(href, this.#refCount.get(href) + 1)
+            return this.#cache.get(href)
+        }
         const childList = this.#children.get(parent)
         if (!childList?.includes(href)) {
             this.#refCount.set(href, this.#refCount.get(href) + 1)
@@ -937,7 +950,11 @@ class Loader {
         return this.createURL(href, tryLoadBlob, mediaType, parent)
     }
     async loadItemXHTMLContent(item, parents = []) {
-        const url = await this.loadItem(item, parents)
+        // Callers read the source of a section they have just loaded (the
+        // renderer pairs `section.load()` with `section.loadContent()`), and
+        // there is no matching unload for this call, so reuse the reference
+        // they already hold rather than taking one that is never released.
+        const url = this.#cache.get(item?.href) ?? await this.loadItem(item, parents)
         if (url) return this.#cacheXHTMLContent.get(url)?.data
     }
     tryImageEntryItem(path) {


### PR DESCRIPTION
## Problem

Opening a footnote popup on a note whose target lives in the section you are reading, then dismissing it, twice, revokes that chapter's blob URLs, including its images, while the reading view is still displaying them.

Reported downstream as: reading a novel with both footnotes and illustrations, tapping footnote content three or more times makes the illustrations impossible to open until the book is closed and reopened.

## Root cause

`Loader.ref()` recorded already-counted hrefs in a `#children` list keyed by the parent document:

```js
ref(href, parent) {
    const childList = this.#children.get(parent)
    if (!childList?.includes(href)) { ...increment... }
```

A top-level load, meaning a view opening a section, passes `parent === undefined`, so every top-level load in the book shared a single `#children.get(undefined)` bucket. Nothing ever calls `unref(undefined)`, so that bucket is never cleared. Once a section href was in it, later `ref()` calls became no-ops while `unloadItem()` still decremented, and the count underflowed to zero.

`FootnoteHandler#showFragment` opens a second `foliate-view` on the same book object, so the popup runs `section.load()` for a section the reading view already holds, and dismissing it runs `section.unload()` (`view.close()` -> `Paginator.destroy()` -> `#destroyAllViews()` -> `sections[i].unload()`). Measured refcount for the displayed section:

| step | count | effect |
|---|---|---|
| reading view loads it | 1 | |
| popup 1 opens | 2 | `ref` counted, bucket now holds the href |
| popup 1 dismissed | 1 | still alive |
| popup 2 opens | 1 | **`ref` skipped** (bucket already has it) |
| popup 2 dismissed | 0 | **revoked, with all child resources** |

An `<img>` that has already decoded stays painted after its blob URL is revoked, so the page looks unaffected and only a fresh fetch of the image fails. `createURL` skips the child list when there is no parent, which is why the first popup counts correctly and only the second underflows.

## Fix

Always count a reference that has no parent: a top-level load is released by exactly one `unloadItem`, so it must be counted every time. The child-list dedup stays for real parents, where it correctly stops one document double-counting a resource it references twice.

That alone would leak, because `loadItemXHTMLContent` is a second unbalanced top-level `loadItem` caller: the renderer pairs `section.load()` with `section.loadContent()` (paginator.js:3490 and :3718) but only the load is matched by an `unload`. The shared bucket had been absorbing that accidentally. So `loadItemXHTMLContent` now reuses the reference its caller already holds instead of taking one nothing releases.

These are the only two top-level `loadItem` callers; `loadHref` and `replaceString` always pass a non-empty `parents`.

## Verification

Downstream unit tests cover both halves, and each fails without its half:

- repeated popup load/unload cycles on a section the reading view holds must revoke nothing, and the section must still be freed once the reader lets go
- `load()` + `loadContent()` per view must still reach zero after one `unload()`, so sections are not leaked

Also verified in a browser against the reported scenario: before, the illustration's blob URL died on the second dismissal and the image viewer stopped opening; after, ten load/unload cycles revoke nothing and the illustration still opens.