### PR TITLE
fix(cbz): compare page paths segment by segment for reading order

### DIFF
--- a/comic-book.js
+++ b/comic-book.js
@@ -92,10 +92,24 @@ export const makeComicBook = async ({ entries, loadBlob, getSize, getComment }, 
     }
 
     const exts = ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg', '.jxl', '.avif']
+    // Compare paths segment by segment: sorting whole paths as strings puts
+    // "Chapter 0060 (2)/001.jpg" before "Chapter 0060/001.jpg" (a space sorts
+    // before a slash), showing part 2 of a split chapter first. Numeric
+    // collation also keeps "2.jpg" ahead of "10.jpg".
+    const collator = new Intl.Collator([], { numeric: true })
+    const comparePaths = (a, b) => {
+        const as = a.split('/'), bs = b.split('/')
+        const len = Math.min(as.length, bs.length)
+        for (let i = 0; i < len; i++) {
+            const cmp = collator.compare(as[i], bs[i])
+            if (cmp) return cmp
+        }
+        return as.length - bs.length
+    }
     const files = entries
         .map(entry => entry.filename)
         .filter(name => exts.some(ext => name.endsWith(ext)))
-        .sort()
+        .sort(comparePaths)
     if (!files.length) throw new Error('No supported image files in archive')
 
     const book = {}


### PR DESCRIPTION
## Problem

A CBZ chapter split across folders that share a chapter number, such as `Chapter 0060/` and `Chapter 0060 (2)/`, renders part 2 before part 1 (readest/readest#5745).

Image paths are flattened into one list and sorted as plain strings. After the shared prefix `Chapter 0060`, the comparison is `" (2)/001.jpg"` vs `"/001.jpg"`, and a space (0x20) sorts before a slash (0x2F), so the `(2)` folder wins.

Upstream's newer `.sort(new Intl.Collator([], { numeric: true }).compare)` on whole paths does not fix this either: the collator still ranks the space-paren run before the slash (verified empirically).

## Fix

Compare paths segment by segment: split on `/`, compare each segment with a numeric collator, and let the shorter path win at divergence so a folder that is a prefix of a sibling sorts first. Numeric collation also fixes unpadded page names (`2.jpg` before `10.jpg`).

Order produced for the report's layout:

```
Chapter 0060/001.jpg
Chapter 0060/002.jpg
Chapter 0060 (2)/001.jpg
Chapter 0060 (2)/002.jpg
Chapter 0060 (3)/001.jpg
Chapter 0060 (10)/001.jpg
Chapter 0061/001.jpg
```

## Tests

Regression test lands in the app repo (`src/__tests__/foliate-cbz-page-order.test.ts`) alongside the submodule bump; it fails against the old sort and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)