### PR TITLE
Keep the anchor when a container scroll leaves it on the page

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -3287,6 +3287,24 @@ export class Paginator extends HTMLElement {
             this.#getRectMapper(targetView))
         return range ? { range, index: this.#primaryIndex } : undefined
     }
+    // Whether the current Range anchor starts inside the visible range.
+    // Fraction and Element anchors are never considered visible, so they
+    // keep being replaced by the visible range as before.
+    #anchorIsVisible(range) {
+        const anchor = this.#anchor
+        if (!anchor?.startContainer) return false
+        const node = anchor.startContainer
+        // comparePoint throws for a node rooted outside the range's document,
+        // i.e. an anchor in another section or in a torn-down document.
+        if (!node.isConnected || node.ownerDocument !== range.startContainer.ownerDocument)
+            return false
+        try {
+            return range.comparePoint(node, anchor.startOffset) === 0
+        } catch {
+            // The anchored text node has been shortened since (IndexSizeError).
+            return false
+        }
+    }
     // Determine which view is primary based on scroll position
     #detectPrimaryView() {
         if (this.#views.size <= 1) return
@@ -3360,9 +3378,18 @@ export class Paginator extends HTMLElement {
         if (!range) return
         this.#lastVisibleRange = range
         // don't set new anchor if relocation was to scroll to anchor
-        if (reason !== 'selection' && reason !== 'navigation' && reason !== 'anchor')
+        if (reason === 'selection' || reason === 'navigation' || reason === 'anchor')
+            this.#justAnchored = true
+        // The scroll that re-anchoring itself performs (a resize re-render)
+        // lands here through the debounced container scroll listener. Taking
+        // the reflowed page's visible range as the new anchor then moves the
+        // anchor to that page's start, which precedes the old anchor whenever
+        // the two layouts' page boundaries differ, so the next resize back
+        // settles one page earlier every time (readest#5808). A container
+        // scroll that keeps the anchor on the page is not a navigation away
+        // from it: keep the anchor.
+        else if (reason !== 'container-scroll' || !this.#anchorIsVisible(range))
             this.#anchor = range
-        else this.#justAnchored = true
 
         const index = visibleIndex ?? this.#primaryIndex
         const primaryView = this.#primaryView


### PR DESCRIPTION
## Summary

Rotating a phone from portrait to landscape and back moved the reader one page back, and every further rotation moved it back again (readest/readest#5808).

## Root cause

A resize re-renders and restores `#anchor` with reason `'anchor'`, which correctly leaves the anchor alone. But the scroll that this restore performs also reaches the debounced container `scroll` listener, which in paginated mode calls `#afterScroll('container-scroll')` and unconditionally replaced `#anchor` with the visible range of the *reflowed* layout. That range starts at the new page's first character, which precedes the old anchor whenever the two layouts' page boundaries differ (nearly always), so the next resize back settled on the page before, and the anchor kept walking backwards on every cycle.

The scrolled-mode branch of the same listener already skips the relocate that follows an anchor scroll via `#justAnchored`; the paginated branch had no such guard.

## Fix

In `#afterScroll`, a `'container-scroll'` relocate keeps the current Range anchor when that anchor still starts inside the new visible range: a container scroll that leaves the anchor on the page is not a navigation away from it. Scrolls that move the anchor off the page (screen-reader paging), fraction and element anchors, and every other relocate reason behave exactly as before. No one-shot flag, so nothing lingers when an anchor scroll happens to produce no scroll event.

## Test plan

- Regression test in readest (Chromium): `paginator-resize-anchor.browser.test.ts` opens the sample EPUB at 400x700, turns two pages, resizes 700x400 and back twice with the 250 ms scroll debounce allowed to fire in between, and expects the same page. Fails on the previous commit (page 2 becomes page 1), passes with this change.
- Full readest browser suite (39 files) and unit suite pass.
- Verified on a Xiaomi 13 (Android) build: see the readest PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
