### PR TITLE
Expose loadHref on sections for resources scripts reference after load

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1219,6 +1219,11 @@ ${doc.querySelector('parsererror').innerText}`)
                 unload: () => this.#loader.unloadItem(item),
                 loadText: () => this.#loader.loadText(item.href),
                 loadContent: () => this.#loader.loadItemXHTMLContent(item),
+                // Load a resource a script references after the section was
+                // rendered (a <video src> built on click); `loadReplaced` only
+                // saw what was in the markup. The section is its parent, so it
+                // is released together with the section.
+                loadHref: href => this.#loader.loadHref(href, item.href),
                 createDocument: () => this.loadDocument(item),
                 size: this.getSize(item.href),
                 cfi: this.resources.cfis[index],


### PR DESCRIPTION
## Problem

Interactive EPUBs build resource references at run time, after the section has been rendered. Kotobee-exported books are the common case: the page markup carries no `<video>` at all, just an encrypted payload, and `kotobeeInteractive.js` creates the element on the play click with a path relative to the section:

```js
n.setAttribute("src", kInteractive.cleanURL("../../../video/1_1-lets-get-started.mp4"))
```

`loadReplaced` only rewrites what was in the markup at load time, and the section document is served from a `blob:` URL, so a relative path added later resolves to nothing. The media element ends up at `networkState 3` (NO_SOURCE) and errors within milliseconds; Kotobee's own error handler then tears its player down, leaving an empty box.

## Change

Add `loadHref` to the section object so a renderer can route such a reference through the loader:

```js
loadHref: href => this.#loader.loadHref(href, item.href),
```

The resource is loaded with the section as its parent, so it is reference-counted as a child and released together with the section — repeated plays reuse the cached blob rather than leaking one per click.

No behaviour changes for existing callers; this only adds a method.

## Downstream

Used by readest/readest, which watches the section document for media, poster and inline `url()` references that scripts introduce and rewrites them through this method. Verified there with the reporter's book (readest/readest#1812) in Chromium and on Android: the clip plays with a blob `src` and `poster`, `readyState 4`, no media error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)