### PR TITLE
fix(fixed-layout): size bitmap spine items by their natural image size

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -5,7 +5,7 @@ const parseViewport = str => str
     ?.filter(x => x)
     ?.map(x => x.split('=').map(x => x.trim()))
 
-const getViewport = (doc, viewport) => {
+export const getViewport = (doc, viewport) => {
     // use `viewBox` for SVG
     if (doc.documentElement.localName === 'svg') {
         const [, , width, height] = doc.documentElement
@@ -16,7 +16,13 @@ const getViewport = (doc, viewport) => {
     // get `viewport` `meta` element
     const meta = parseViewport(doc.querySelector('meta[name="viewport"]')
         ?.getAttribute('content'))
-    if (meta) return Object.fromEntries(meta)
+    if (meta) {
+        const props = Object.fromEntries(meta)
+        // A bitmap spine item is loaded as the browser's own image document,
+        // whose synthetic meta (`width=device-width, minimum-scale=0.1`) has no
+        // page size; only a numeric width and height describe a fixed page
+        if (parseFloat(props.width) > 0 && parseFloat(props.height) > 0) return props
+    }
 
     // fallback to book's viewport
     if (typeof viewport === 'string') return parseViewport(viewport)


### PR DESCRIPTION
## Summary

A bitmap spine item (`image/jpeg` etc. directly in the spine, as in the IDPF `haruko-jpeg` and `page-blanche-bitmaps-in-spine` samples) is loaded by the browser as its own image document, which carries a synthetic `<meta name="viewport" content="width=device-width, minimum-scale=0.1">`. `getViewport` took that meta at face value, so the page had no numeric size and collapsed to the 300x150 iframe default.

- Only accept a viewport meta whose width and height are numeric; otherwise fall through to the book viewport and the image's natural size as before.
- Export `getViewport` so the reader app can unit test it (readest/readest#480).

## Test plan

- [x] readest unit test `foliate-fxl-image-spine-viewport.test.ts` (image document -> natural size; numeric meta kept; non-numeric meta falls back to the book viewport)
- [x] Chrome: `haruko-jpeg.epub` and `page-blanche-bitmaps-in-spine.epub` render full pages instead of a 300x150 stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)