### PR TITLE
fix(mobi): serialize KF8 loadRaw so overlapping section loads stay ordered

### DIFF
--- a/mobi.js
+++ b/mobi.js
@@ -963,6 +963,7 @@ class KF8 {
     #rawTail = new Uint8Array()
     #lastLoadedHead = -1
     #lastLoadedTail = -1
+    #rawQueue = Promise.resolve()
     #type = MIME.XHTML
     #inlineMap = new Map()
     constructor(mobi) {
@@ -1126,7 +1127,22 @@ class KF8 {
     // NOTE: there doesn't seem to be a way to access text randomly?
     // how to know the decompressed size of the records without decompressing?
     // 4096 is just the maximum size
-    async loadRaw(start, end) {
+    //
+    // `#loadRawLocked` appends records to `#rawHead` / `#rawTail` across an
+    // `await`, so overlapping calls would interleave and land the records in
+    // completion order instead of index order, shifting every byte offset
+    // after the first out-of-order append. That never showed up when the book
+    // is an in-memory `File` (slices settle in issue order), but a file read
+    // through ranged requests finishes out of order, and the renderer does
+    // overlap loads — it preloads the adjacent section while another one is
+    // still loading. Serialize on a promise chain so the walk stays ordered;
+    // whichever call runs second usually finds its window already buffered.
+    loadRaw(start, end) {
+        const result = this.#rawQueue.then(() => this.#loadRawLocked(start, end))
+        this.#rawQueue = result.then(() => {}, () => {})
+        return result
+    }
+    async #loadRawLocked(start, end) {
         // here we load either from the front or back until we have reached the
         // required offsets; at worst you'd have to load half the book at once
         const distanceHead = end - this.#rawHead.length


### PR DESCRIPTION
Fixes the parser half of readest/readest#5918 — some AZW3 books render `�` in place of Chinese characters, drop runs of text, and their TOC entries navigate nowhere.

## Root cause

KF8 has no random access to its text. `loadRaw(start, end)` walks the PalmDOC records from the front (or the back) into a growing `#rawHead` / `#rawTail` accumulator and slices the requested window out of it. That walk `await`s a record read on every iteration **while mutating the shared accumulator**, so two overlapping `loadRaw` calls append their records in *completion* order rather than index order. From the first out-of-order append onward, every byte offset into the accumulator is wrong.

The consequences, all visible in the linked issue:

- sections assemble bytes that belong elsewhere in the file, so UTF-8 sequences split at the seams render as `U+FFFD`;
- the skeleton's markup truncates mid-page, so the rest of the chapter never renders;
- `resolveHref`'s fragment-selector extraction reads the wrong bytes, so `kindle:pos:` TOC links resolve to nothing.

The renderer really does overlap loads — `paginator.js` fires `#preloadNext` / `#loadAdjacentSection` unawaited while `goTo` runs its own `section.load()`.

## Why this went unnoticed

With an in-memory `File`, `slice().arrayBuffer()` settles in issue order, so the appends happen to stay ordered and the race is invisible. It only bites once the book is read through ranged requests that finish out of order — which is how readest opens a book on desktop and Android, and matches the issue's "Windows and Android, not web" report.

## Fix

Serialize `loadRaw` on a promise chain, with the original body moved to `#loadRawLocked`. The walk is inherently sequential anyway, and because the accumulator is retained, whichever call runs second usually finds its window already buffered rather than re-reading anything.

## Verification

Covered downstream by a readest regression test that drives a `File` whose slices settle after a jittered delay:

- a 12-chapter Chinese AZW3 fixture: **6 of 12 sections** mismatch the serial read before this change, 0 after;
- the reporter's actual 11 MB book: **58 of 170 sections** mismatch before, 0 after, across three jitter seeds.

`npx eslint mobi.js` is clean.