### PR TITLE
fix(paginator): turn the page on a drag

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -198,6 +198,10 @@ const VIEW_TRANSITION_CLASSES = [
 const RELEASE_VELOCITY_WINDOW_MS = 90
 const RELEASE_PAUSE_THRESHOLD_MS = 80
 const SLIDE_RELEASE_PROJECTION_MS = 240
+// Fraction of a page a drag-follow swipe must cover for the release to
+// commit the turn on displacement alone, when the finger is too slow to
+// register as a flick.
+const DRAG_TURN_DISTANCE_RATIO = 0.06
 const LAYERED_EDGE_REGION = 0.18
 const LAYERED_EARLY_CLAIM_PX = 6
 const LAYERED_EARLY_SAMPLE_INTERVAL_MS = 80
@@ -2268,7 +2272,25 @@ export class Paginator extends HTMLElement {
             const max = Math.abs(offset) + b
             const v =  snapping ? velocity : avgVelocity
             const d = v * sign * size * (aligned ? 1 : 0)
-            const snapOffset = (isNaN(d) ? 0 : snapping ? d * 2 : d * 10)
+            const velocityBased = isNaN(d) ? 0 : snapping ? d * 2 : d * 10
+            // A slow but deliberate drag still turns the page. The drag-follow
+            // release above is judged by its flick velocity alone (`d * 2`), so
+            // a finger that drags most of a page across and then eases to a
+            // stop before lifting scores ~0 and springs back: the page visibly
+            // followed the finger, yet nothing commits, and the reader has to
+            // flick hard to turn. Judge that release by the displacement the
+            // reader actually saw. Alignment uses the displacement ratio, not
+            // `aligned`, for the same reason it does on the displacement path:
+            // at low speed the lift-off velocities are jitter.
+            const distanceBased = snapping
+                && Math.abs(dx) > Math.abs(dy)
+                && Math.abs(dx) > size * DRAG_TURN_DISTANCE_RATIO
+                ? Math.sign(dx) * sign * size
+                : 0
+            // Whichever offset commits more strongly wins, so a fast flick
+            // keeps its existing multi-page reach.
+            const snapOffset = Math.abs(velocityBased) > Math.abs(distanceBased)
+                ? velocityBased : distanceBased
             page = Math.floor(Math.max(min, Math.min(max, (start + end) / 2 + snapOffset)) / size)
         }
         const dir = page < 0 ? -1 : page >= pages ? 1 : null


### PR DESCRIPTION
## Problem

A s/low swipe doesn't turn the page, you have to flick hard.

Drag a finger across part of the page. On release the page springs back and nothing happens.

## Cause

On the drag-follow path `snap()` decides the turn from the release velocity
alone, with only a `* 2` multiplier:

```js
const snapOffset = (isNaN(d) ? 0 : snapping ? d * 2 : d * 10)
```

A finger that decelerates before lift-off scores ~0, so the offset is ~0 no matter how far the drag travelled. 

## Fix

Also judge that release by displacement, and keep whichever offset commits more strongly:

```js
const velocityBased = isNaN(d) ? 0 : snapping ? d * 2 : d * 10
const distanceBased = snapping
    && Math.abs(dx) > Math.abs(dy)
    && Math.abs(dx) > size * DRAG_TURN_DISTANCE_RATIO
    ? Math.sign(dx) * sign * size
    : 0
const snapOffset = Math.abs(velocityBased) > Math.abs(distanceBased)
    ? velocityBased : distanceBased
```

A drag past 6% of the page turns it.

Video below: the first half is the current behaviour on v0.12.6, the second is my fork with this patch applied.

https://github.com/user-attachments/assets/5970ecbb-6d22-45e0-9422-62034a9e1043