### PR TITLE
fix(opds): read the Dublin Core date before Atom published

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -217,8 +217,8 @@ export const getPublication = entry => {
             contributor: children.filter(filter('contributor')).map(getPerson),
             publisher: children.find(filterDC('publisher'))?.textContent ?? undefined,
             published: (children.find(filterDCTERMS('issued'))
-                ?? children.find(filter('published'))
-                ?? children.find(filterDC('date')))?.textContent ?? undefined,
+                ?? children.find(filterDC('date'))
+                ?? children.find(filter('published')))?.textContent ?? undefined,
             language: children.find(filterDC('language'))?.textContent ?? undefined,
             identifier: children.find(filterDC('identifier'))?.textContent ?? undefined,
             subject: children.filter(filter('category')).map(category => ({


### PR DESCRIPTION
## Problem

Books browsed or downloaded from a **calibre** OPDS catalog resolve their publication date to the date the book was **added to the calibre library**, not its `pubdate`.

The two calibre-family servers mean opposite things by Atom `<published>`:

| Server | `atom:published` | Dublin Core date | `dcterms:issued` |
| --- | --- | --- | --- |
| **calibre**, own content server (`src/calibre/srv/opds.py`, `ACQUISITION_ENTRY`) | `mi.timestamp` - **date ADDED** | `<dcterms:date>` = `mi.pubdate` - the real one | never emitted |
| **Calibre-Web** (`cps/templates/feed.xml`) | `Books.pubdate` - **the real one** | not emitted | never emitted |

The current order is `dcterms:issued`, then `atom:published`, then `filterDC('date')`. For calibre, step 2 matches the added-date and the real `pubdate` sitting at step 3 is never reached.

This was the target of #66, whose description already identified it: *"Calibre-based catalogs may use `<published>` for the date a book entered the catalog while `<dcterms:issued>` contains the book's publication date."* That change hoisted `dcterms:issued` only, and calibre's own server emits no `dcterms:issued` at all, so the catalog it names was not reached.

Reported downstream at readest/readest#6003 (via https://www.reddit.com/r/Calibre/comments/1w20i2y/).

## Change

Read the Dublin Core dates above `atom:published`:

```js
published: (children.find(filterDCTERMS('issued'))
        ?? children.find(filterDC('date'))
        ?? children.find(filter('published')))?.textContent ?? undefined,
```

`filterDC` already covers both `dc:date` and `dcterms:date`, so this satisfies every row of the table above:

- **calibre** resolves to `dcterms:date`, its real pubdate.
- **Calibre-Web** has no Dublin Core date and still falls through to `atom:published`, its real pubdate. No regression.
- The `dcterms:issued` catalog #66 was written for keeps winning, unchanged.

RFC 4287 supports the same ordering on principle: `atom:published` is when the **entry** was published to the feed, not when the book was published, so it is the correct last resort.

This restores the relative order of `atom:published` and the Dublin Core date to what upstream had before it was changed here (`ad5ec4d` read `dcterms:issued ?? filterDC('date')` and did not consult `atom:published`); `atom:published` stays as the added fallback, just below the Dublin Core dates rather than above them.

## Verification

- `npx eslint opds.js`: 0 errors. The 2 `comma-dangle` warnings are pre-existing on lines this PR does not touch (verified against a pristine `origin/main`).
- Five parser regression tests added downstream in readest/readest#6008, covering calibre (`dcterms:date` beats `atom:published`), `dc:date`, `dcterms:issued` precedence, the Calibre-Web fallback, and the no-date case. Red before this commit (2 failures), green after (18/18).
