### PR TITLE
feat(fixed-layout): add a horizontal pan lock for zoomed pages

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -118,14 +118,19 @@ export const computeScrollPinchTransform = ({
 })
 
 // Scroll offsets to apply to the host (`overflow:auto`) after rendering a
-// paginated page. Horizontal is always re-centered so the page sits in the
-// middle of the viewport. Vertical is reset to the top only on a page turn:
-// a tall fit-width page overflows the host vertically, and without the reset the
-// freshly-shown page inherits the previous page's offset and opens scrolled to
-// the bottom (#4683). Plain re-renders (resize, zoom, theme) keep the reader's
-// current vertical position within the page.
-export const computePaginatedScroll = ({ elementWidth, containerWidth, scrollTop, pageTurn }) => ({
-    scrollLeft: (elementWidth - containerWidth) / 2,
+// paginated page. Horizontal is re-centered so the page sits in the middle of
+// the viewport, unless the horizontal pan lock is on: there the offset the
+// reader panned to is carried over, so a zoomed page whose side margins are
+// cropped out of view stays cropped across page turns (#5976). Vertical is
+// reset to the top only on a page turn: a tall fit-width page overflows the
+// host vertically, and without the reset the freshly-shown page inherits the
+// previous page's offset and opens scrolled to the bottom (#4683). Plain
+// re-renders (resize, zoom, theme) keep the reader's current vertical position
+// within the page.
+export const computePaginatedScroll = ({
+    elementWidth, containerWidth, scrollTop, scrollLeft, pageTurn, lockPanX,
+}) => ({
+    scrollLeft: lockPanX ? scrollLeft : (elementWidth - containerWidth) / 2,
     scrollTop: pageTurn ? 0 : scrollTop,
 })
 
@@ -207,7 +212,7 @@ export const applyOverlayerViewBox = (frame, overlayer) => {
 }
 
 export class FixedLayout extends HTMLElement {
-    static observedAttributes = ['zoom', 'scale-factor', 'spread', 'flow', 'scroll-gap', 'scroll-direction']
+    static observedAttributes = ['zoom', 'scale-factor', 'spread', 'flow', 'scroll-gap', 'scroll-direction', 'lock-pan-x']
     #root = this.attachShadow({ mode: 'open' })
     #observer = new ResizeObserver(() => this.#render())
     #spreads
@@ -223,6 +228,8 @@ export class FixedLayout extends HTMLElement {
     #scaleFactor = 1.0
     #totalScaleFactor = 1.0
     #scrollLocked = false
+    // Horizontal offset handed over by #showSpread for the next #render().
+    #pannedX = null
     #isOverflowX = false
     #isOverflowY = false
     #preloadCache = new Map()
@@ -392,6 +399,16 @@ export class FixedLayout extends HTMLElement {
         :host([flow="scrolled"]) .scroll-page {
             touch-action: pan-x pan-y;
         }
+        /* Horizontal pan lock: the finger only moves the page up and down, so a
+           zoomed-in page panned to hide its wide side margins can't drift back
+           out of alignment with every slightly-diagonal swipe (#5976). Two
+           fingers stay unlisted, so pinch is still delivered to JS. Exempt
+           horizontal scroll flow, where x is the reading axis and locking it
+           would strand the reader. */
+        :host([lock-pan-x]:not([flow="scrolled"][scroll-direction="horizontal"])),
+        :host([lock-pan-x]:not([flow="scrolled"][scroll-direction="horizontal"])) .scroll-page {
+            touch-action: pan-y;
+        }
         :host([flow="scrolled"]) .scroll-container {
             display: flex;
             flex-direction: column;
@@ -464,6 +481,9 @@ export class FixedLayout extends HTMLElement {
                 if (anchor) this.#restoreScrollModeAnchor(anchor)
                 break
             }
+            case 'lock-pan-x':
+                this.#applyPanLockToFrames()
+                break
             case 'scroll-direction': {
                 const horizontal = value === 'horizontal'
                 if (horizontal === this.#scrollHorizontal) break
@@ -477,6 +497,22 @@ export class FixedLayout extends HTMLElement {
                 break
             }
         }
+    }
+    // `touch-action` doesn't cross an iframe boundary: a touch that lands on page
+    // content is governed by that document's own value, so the host's `pan-y`
+    // alone still leaves the page pannable sideways (#5976). Mirror the lock
+    // inside every frame, with the same horizontal-scroll-flow exemption the
+    // stylesheet makes.
+    #applyPanLock(doc) {
+        if (!doc?.documentElement) return
+        const locked = this.hasAttribute('lock-pan-x')
+            && !(this.getAttribute('flow') === 'scrolled'
+                && this.getAttribute('scroll-direction') === 'horizontal')
+        doc.documentElement.style.touchAction = locked ? 'pan-y' : ''
+    }
+    #applyPanLockToFrames() {
+        for (const iframe of this.#root.querySelectorAll('iframe'))
+            this.#applyPanLock(iframe.contentDocument)
     }
     async #createFrame({ index, src: srcOption, detached = false }) {
         const srcOptionIsString = typeof srcOption === 'string'
@@ -512,6 +548,7 @@ export class FixedLayout extends HTMLElement {
         return new Promise(resolve => {
             iframe.addEventListener('load', () => {
                 const doc = iframe.contentDocument
+                this.#applyPanLock(doc)
                 iframe.dataset.sectionIndex = index
                 this.dispatchEvent(new CustomEvent('load', { detail: { doc, index } }))
                 const { width, height } = getViewport(doc, this.defaultViewport)
@@ -536,6 +573,12 @@ export class FixedLayout extends HTMLElement {
             return []
         }
         if (!side) return []
+        // The offset the reader panned to, read before transform()'s resizes
+        // let the browser clamp it. #showSpread hands over its own snapshot:
+        // by the time a page turn reaches us its frame swap has already
+        // clamped the live value to 0 (#5976).
+        const pannedX = this.#pannedX ?? this.scrollLeft
+        this.#pannedX = null
         const left = this.#left ?? {}
         const right = this.#center ?? this.#right ?? {}
         const target = side === 'left' ? left : right
@@ -642,7 +685,9 @@ export class FixedLayout extends HTMLElement {
                 elementWidth: element.clientWidth,
                 containerWidth,
                 scrollTop: container.scrollTop,
+                scrollLeft: pannedX,
                 pageTurn,
+                lockPanX: this.hasAttribute('lock-pan-x'),
             })
             container.scrollLeft = scrollLeft
             container.scrollTop = scrollTop
@@ -742,6 +787,11 @@ export class FixedLayout extends HTMLElement {
             ? [this.#center?.element]
             : [this.#left?.element, this.#right?.element]
 
+        // Making the outgoing frames absolute collapses the host's scrollable
+        // width, so the browser clamps the scroll offset to 0 before #render()
+        // gets to read it. Under the horizontal pan lock that offset is the
+        // one thing the page turn has to preserve, so snapshot it first.
+        if (this.hasAttribute('lock-pan-x')) this.#pannedX = this.scrollLeft
         Array.from(this.#root.children).forEach(child => {
             const isVisible = visibleFrames.includes(child)
             Object.assign(child.style, {
@@ -990,6 +1040,7 @@ export class FixedLayout extends HTMLElement {
         return new Promise(resolve => {
             iframe.addEventListener('load', () => {
                 const doc = iframe.contentDocument
+                this.#applyPanLock(doc)
                 iframe.dataset.sectionIndex = pageData.index
                 this.dispatchEvent(new CustomEvent('load', { detail: { doc, index: pageData.index } }))
                 const { width, height } = getViewport(doc, this.defaultViewport)

--- a/pdf.js
+++ b/pdf.js
@@ -212,7 +212,7 @@ const activeRenderTasks = new WeakMap()
 const renderGenerations = new WeakMap()
 
 // Set up panning and selection event handlers once per iframe document
-const setupPanningEvents = (doc) => {
+export const setupPanningEvents = (doc) => {
     if (doc._readestEventsInitialized) return
     doc._readestEventsInitialized = true
 
@@ -287,11 +287,17 @@ const setupPanningEvents = (doc) => {
 
             const dx = e.screenX - startX
             const dy = e.screenY - startY
+            // Panning a zoomed page is a script write, not native scrolling, so
+            // `touch-action` cannot constrain it. The renderer mirrors the
+            // horizontal pan lock onto this document's root element (#5976);
+            // read it back so a drag that is only slightly diagonal can't shift
+            // the page sideways again.
+            const lockX = doc.documentElement.style.touchAction === 'pan-y'
 
             if (scrollParent === window) {
-                window.scrollTo(scrollLeft - dx, scrollTop - dy)
+                window.scrollTo(lockX ? window.scrollX : scrollLeft - dx, scrollTop - dy)
             } else {
-                scrollParent.scrollLeft = scrollLeft - dx
+                if (!lockX) scrollParent.scrollLeft = scrollLeft - dx
                 scrollParent.scrollTop = scrollTop - dy
             }
         }


### PR DESCRIPTION
Renderer side of readest/readest#5976.

A zoomed-in page on a phone gets panned sideways so its wide side margins fall outside the viewport. Keeping it there is the problem: every swipe that is even slightly diagonal shifts the page a little left or right, so the reader has to re-centre the text again and again, and in paginated mode the next page snaps back to centre regardless.

This adds a `lock-pan-x` attribute on `<foliate-fxl>` that pins the horizontal offset.

## Why it takes three layers

A zoomed page can move sideways three different ways, and blocking any one alone leaves the bug:

1. **Host CSS.** `touch-action: pan-y` on the host and `.scroll-page`, so native scroll only follows the y axis. Two fingers stay unlisted, so pinch is still delivered to JS (the base was already `pan-x pan-y`, so browser pinch-zoom was never enabled and the lock only drops the `pan-x` token).
2. **Per-frame mirror.** `touch-action` does not cross an iframe boundary: a touch that lands on page content is governed by that document's own value, so the host's declaration never reaches it. `#applyPanLock(doc)` writes the same value onto each frame's root element, from both frame load handlers and from the attribute callback.
3. **`setupPanningEvents` in `pdf.js`** — the layer that actually matters for a zoomed PDF. Panning there is a pointer handler writing `scrollLeft` directly, which no `touch-action` value can constrain. It now reads the mirrored lock back off the document root and skips the horizontal write.

Layer 3 is why a CSS-only version tested green in a desktop browser and did nothing on a real device: the JS pan only engages when there is no text under the pointer, so a swipe starting over text fell through to native scroll and was blocked, while one starting anywhere else was not.

## Paginated flow

`computePaginatedScroll` now carries the current offset across a page turn instead of re-centring. `#showSpread` snapshots it first: making the outgoing frames `position: absolute` collapses the host's scrollable width, so the browser clamps the live value to 0 before `#render` can read it.

Horizontal scroll flow is exempt throughout, since x is the reading axis there and locking it would strand the reader on one page.

## Verification

Tests live in the readest app (`fixed-layout-paginated-scroll.test.ts`, plus real-Chromium `fixed-layout-pan-lock.browser.test.ts` and `pdf-pan-lock.browser.test.ts`). Verified on a Xiaomi 13 / Android 16 with a zoomed PDF: diagonal swipes and repeated vertical flings hold `scrollLeft` exactly, where before they walked it from 295 to 98; pinch zoom still works; the lock is reversible and survives a reload.