### PR TITLE
fix(paginator): lay the section out while its scripts run, and clamp canvas

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -710,10 +710,18 @@ class View {
             justifyContent: 'flex-start',
             alignItems: 'center',
         })
+        // Hidden but laid out, rather than `display: none`. A section's own
+        // scripts run while the document loads, before this view has rendered,
+        // and a display:none subtree has no boxes at all, so anything the book
+        // measures then comes back zero. The IDPF `trees` sample sizes its
+        // canvas backing store from the element's own width, so it ended up
+        // 0x0 and drew nothing at all (readest/readest#6041). `visibility:
+        // hidden` still paints nothing while giving those scripts real
+        // geometry to measure.
         Object.assign(this.#iframe.style, {
             overflow: 'hidden',
             border: '0',
-            display: 'none',
+            visibility: 'hidden',
             width: '100%', height: '100%',
         })
         // `allow-scripts` is needed for events because of WebKit bug
@@ -740,7 +748,7 @@ class View {
 
                 this.#iframe.setAttribute('aria-label', doc.title)
                 // it needs to be visible for Firefox to get computed style
-                this.#iframe.style.display = 'block'
+                this.#iframe.style.visibility = 'visible'
                 const { vertical, rtl } = getDirection(doc)
                 this.docBackground = getBackground(doc)
                 doc.body.style.background = 'none'
@@ -790,14 +798,14 @@ class View {
                 // have been torn down or reloaded meanwhile — don't render into
                 // a stale document.
                 if (this.document !== doc) return resolve()
-                this.#iframe.style.display = 'none'
+                this.#iframe.style.visibility = 'hidden'
 
                 this.#vertical = vertical
                 this.#rtl = rtl
 
                 this.#contentRange.selectNodeContents(doc.body)
                 const layout = beforeRender?.({ vertical, rtl })
-                this.#iframe.style.display = 'block'
+                this.#iframe.style.visibility = 'visible'
                 this.render(layout)
                 bgRendered = true
                 this.#observer.observe(doc.body)
@@ -954,7 +962,11 @@ class View {
         // `auto`, so height:100% resolves to 0 and the cover collapses out of
         // sight (#4379). Apply it only when columnized.
         const applyFullscreen = pageFullscreen && this.#column
-        for (const el of doc.body.querySelectorAll('img, svg, video')) {
+        // `canvas` belongs with the other replaced elements: a book is free to
+        // size one past the page box, and without the clamp it spills over the
+        // column rule and paints on top of the next column's text
+        // (readest/readest#6041).
+        for (const el of doc.body.querySelectorAll('img, svg, video, canvas')) {
             // clear previous inline constraints so we read CSS-authored values,
             // not stale pixel values from a previous resize (#3634)
             el.style.removeProperty('max-width')

--- a/paginator.js
+++ b/paginator.js
@@ -972,7 +972,18 @@ class View {
             el.style.removeProperty('max-width')
             el.style.removeProperty('max-height')
             // preserve max size if they are already set in CSS
-            let { maxHeight, maxWidth } = doc.defaultView.getComputedStyle(el)
+            let { maxHeight, maxWidth, marginLeft: elMarginLeft, marginRight: elMarginRight,
+                marginTop: elMarginTop, marginBottom: elMarginBottom }
+                = doc.defaultView.getComputedStyle(el)
+            // `100%` caps the border box, and the element's own margins sit
+            // outside it, so an element the book sized at or past the column
+            // still hangs its margins over the edge — the IDPF `trees` canvas
+            // carries `margin: 1em` and spilled exactly 2em past the column
+            // rule (readest/readest#6041). Cap the margin box instead.
+            const fill = (a, b) => {
+                const margins = (parseFloat(a) || 0) + (parseFloat(b) || 0)
+                return margins > 0 ? `calc(100% - ${margins}px)` : '100%'
+            }
             if (parseInt(maxWidth) > availableWidth) {
                 maxWidth = `${availableWidth}px`
             }
@@ -981,11 +992,13 @@ class View {
             }
             setStylesImportant(el, {
                 'max-height': vertical
-                    ? (maxHeight !== 'none' && maxHeight !== '0px' ? maxHeight : '100%')
+                    ? (maxHeight !== 'none' && maxHeight !== '0px' ? maxHeight
+                        : fill(elMarginTop, elMarginBottom))
                     : `${height - (applyFullscreen ? 0 : (marginTop + marginBottom))}px`,
                 'max-width': vertical
                     ? `${width - (applyFullscreen ? 0 : (marginLeft + marginRight))}px`
-                    : (maxWidth !== 'none' && maxWidth !== '0px' ? maxWidth : '100%'),
+                    : (maxWidth !== 'none' && maxWidth !== '0px' ? maxWidth
+                        : fill(elMarginLeft, elMarginRight)),
                 'object-fit': 'contain',
                 'page-break-inside': 'avoid',
                 'break-inside': 'avoid',


### PR DESCRIPTION
Two independent defects behind readest/readest#6041, both visible in the IDPF `trees` sample (https://idpf.github.io/epub3-samples/30/samples.html), which is a conformance test for `<canvas>` plus scripting.

## 1. Section scripts measure a zero-sized document

`View`'s iframe was created with `display: none` and only switched to `display: block` inside the iframe's own `load` handler. But a section's scripts run *during* the document load, well before that handler, so they run against a `display: none` subtree, which has no boxes at all. Anything the book measures then comes back zero.

`trees` sizes its canvas backing store from the element's own width:

```js
var width  = $canvas.width();
var height = $canvas.height();
$canvas.attr("width", width);
$canvas.attr("height", height);
```

Measured in the running reader before the change: the canvas CSS box was `256x128`, while `canvas.width x canvas.height` was **`0x0`**. The book then animated into a zero-sized bitmap, so nothing was ever drawn. That is not specific to this sample; it hits any book that sizes something from layout on DOM-ready.

Hiding with `visibility: hidden` instead of `display: none` keeps the iframe unpainted while giving the document real geometry to measure. The three later toggles move to `visibility` for the same reason, so the window in which the unpaginated document is briefly visible (between reading the computed direction/background and rendering) is exactly as it was.

After the change, the same measurement reads `256x128` and the book draws.

## 2. An oversized canvas paints over the next column

Two parts to this one.

`setImageSize` clamped `img, svg, video` to the available page box but not `canvas`. `trees` declares `#canvas { width: 16em; height: 8em; border: 1px solid black; margin: 1em }`, far wider than a column, so the canvas and its border spilled over the column rule and across the next column's text. `canvas` now joins that selector list.

That alone was not enough. The fill value is `max-width: 100%`, which caps the **border** box, and an element's own margins sit outside it — so an element the book sized at or past the column still hangs its margins over the edge. Measured on the sample at a 156px column: border box clamped to 156, plus `1em` either side, for a 188px margin box, i.e. exactly 2em of overhang, which is what painted over the adjacent column. The fill value now subtracts the element's own inline margins (and the block margins in the vertical-writing equivalent), so the margin box is what fits: 124 plus 32, flush with the column edge.

Note this is not specific to `canvas` — any `img` with margins that the book sized to the column had the same overhang.

## Verification

Web build, Chrome, at a 422px-wide reader viewport:

- the chapter canvas draws, and no longer overlaps the adjacent column
- the `titlepage.xhtml` canvas draws, matching the sample's intended layout
- Moby-Dick paginates unchanged, so the visibility swap does not disturb an ordinary book

Readest's suite on top of this submodule: 10780 tests passing, lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
