### PR TITLE
fix(pdf): skip a re-render that would detach the live text-layer ranges

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -210,6 +210,9 @@ let annotationLayerBuilderCSS = null
 const activeRenderTasks = new WeakMap()
 // Generation counter per document to detect stale renders after async gaps
 const renderGenerations = new WeakMap()
+// What each document was last rendered for, so an identical re-render can be
+// skipped instead of rebuilding the text layer (see `render`)
+const renderedFor = new WeakMap()
 
 // Set up panning and selection event handlers once per iframe document
 export const setupPanningEvents = (doc) => {
@@ -375,9 +378,28 @@ const getRenderDpr = (page, zoom) => {
 const render = async (page, doc, zoom, pageColors) => {
     if (!doc) return
 
+    // Rendering tears the text layer down and builds it again, which detaches
+    // every Range held into it -- the sentence ranges TTS is reading from, and
+    // anything anchored for selection or highlighting. fixed-layout re-renders
+    // from a ResizeObserver on any layout change, including the one a page turn
+    // itself causes, so the same page gets rendered twice per turn and the
+    // second pass kills the ranges TTS just built (readest #6071). Skip the work
+    // when nothing that affects the output has changed.
+    const signature = [zoom, pageColors?.background, pageColors?.foreground,
+        getFontScale(doc)].join('|')
+    const rendered = renderedFor.get(doc)
+    if (rendered?.page === page && rendered.signature === signature) return
+
     // Increment generation to invalidate any in-progress render for this doc
     const generation = (renderGenerations.get(doc) || 0) + 1
     renderGenerations.set(doc, generation)
+    renderedFor.set(doc, { page, signature, generation })
+    // Let a later render retry after this one bails without replacing the DOM.
+    // A newer render overwrites the entry with its own generation, so only the
+    // render that still owns it clears it.
+    const forget = () => {
+        if (renderedFor.get(doc)?.generation === generation) renderedFor.delete(doc)
+    }
 
     // Cancel any in-progress render task for this document
     const existingTask = activeRenderTasks.get(doc)
@@ -428,6 +450,7 @@ const render = async (page, doc, zoom, pageColors) => {
         // Render was cancelled or failed — release canvas bitmap memory
         canvas.width = 0
         canvas.height = 0
+        forget()
         return
     } finally {
         if (activeRenderTasks.get(doc) === renderTask) {
@@ -439,6 +462,7 @@ const render = async (page, doc, zoom, pageColors) => {
     if (renderGenerations.get(doc) !== generation || !doc.defaultView) {
         canvas.width = 0
         canvas.height = 0
+        forget()
         return
     }
 
@@ -446,6 +470,7 @@ const render = async (page, doc, zoom, pageColors) => {
     if (!canvasElement) {
         canvas.width = 0
         canvas.height = 0
+        forget()
         return
     }
 
@@ -467,7 +492,10 @@ const render = async (page, doc, zoom, pageColors) => {
     await textLayer.render()
 
     // Bail out if superseded after async text layer render
-    if (renderGenerations.get(doc) !== generation) return
+    if (renderGenerations.get(doc) !== generation) {
+        forget()
+        return
+    }
 
     // Counteract the OS font-size accessibility scaling on the text layer's glyph
     // size only (see getFontScale). `--text-scale-factor` feeds `font-size` and


### PR DESCRIPTION
## Problem

Rendering a PDF page tears the text layer down and builds it again:

```js
const container = doc.querySelector('.textLayer')
container.replaceChildren()
```

That detaches every `Range` held into it — the sentence ranges TTS is reading from, and anything anchored for selection or highlighting.

`fixed-layout.js` re-renders from `#observer = new ResizeObserver(() => this.#render())` on any layout change, including the one a page turn itself causes, and discards the `renderPromises` array that `#render()` returns for exactly this purpose (`fixed-layout.js:808-809` awaits it properly). So every page is rendered **twice** per turn, the second pass landing ~130 ms after the first with nothing about the output changed — after `TTSController` has already built its `TTS` over the first pass.

## Evidence

Traced on a Xiaomi 2211133C (Android 16) by patching `Element.prototype.replaceChildren` inside the PDF iframe. Every page, identical scale and container box:

```
+0ms    page=92 scale=0.9424859427009213 host=393x873 had=101
+193ms  page=92 scale=0.9424859427009213 host=393x873 had=101   <- redundant
+11415ms page=93 …  had=85
+11549ms page=93 …  had=85                                       <- redundant
```

Correlated against `view.tts.next()`:

```
 998  WIPE     page 15 wiped (104 children)   <- awaited, from renderer.goTo
1019  NEW TTS  built over page 15
1021  next ->  "16Pym was a handsome man, boyi…"
1147  WIPE     page 15 wiped AGAIN            <- ResizeObserver, un-awaited
6711  next ->  ""   (empty from here on)
```

Downstream (readest/readest#6071): TTS skipped most paragraphs, highlighted nothing, and advanced as soon as a page came back fully empty — reading one paragraph per page to the end of the book.

## Fix

Guard `render` with what the document was last rendered for — page, zoom, page colours, OS font scale — and return early when none of it changed. Fixing it here rather than in the `ResizeObserver` protects the text layer from *every* redundant render trigger, and skips the rasterisation too.

The entry carries the render's generation, so a bail-out only clears it when a newer render has not already replaced it.

## Verification

1. **Unit test** in readest (`foliate-pdf-redundant-render.test.ts`): a node captured from the first render must still be `isConnected` after an identical second `onZoom`. Red before, green after, plus guard-rails that a zoom change and a `pageColors` change still rebuild.
2. **Browser A/B on the real bundle**: unfixed, every page wiped twice with identical content (`had=2368` → `had=2368`); fixed, once per page, and a node captured at render time survived 4 consecutive page turns.
3. **Device**: rebuilt and installed on the Xiaomi, replaying the original reporter's PDF — 310 non-empty blocks, **zero** empty, a clean page turn, and the word highlight tracking down the page. The old build produced 4 blocks then empties.