### PR TITLE
fix(epub): close unclosed void tags and re-parse as XML before the HTML fallback

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -23,6 +23,39 @@ const MIME = {
     JS: /\/(x-)?(javascript|ecmascript)/,
 }
 
+// a document declared XHTML that the XML parser could not parse
+const isBrokenXHTML = doc => doc.querySelector('parsererror')
+    || !doc.documentElement?.namespaceURI
+// Void elements that Adobe InDesign / Digital Editions exports leave unclosed
+// (`<meta charset="utf-8">` constantly), the usual reason such a file is not
+// well-formed XML. Lowercase only: XHTML is case-sensitive, and an uppercase
+// `<BR>` closed as `<BR/>` would parse as an unknown element instead of a
+// line break, so those files keep taking the HTML path.
+const VOID_ELEMENT_RE = /<(meta|link|br|img|hr|input|col|area|base|embed|param|source|track|wbr)(?=[\s/>])((?:[^<>"']|"[^"]*"|'[^']*')*)>/g
+const closeVoidElements = str => str.replace(VOID_ELEMENT_RE,
+    (tag, name, attrs) => attrs.trimEnd().endsWith('/') ? tag : `<${name}${attrs}/>`)
+// Parse a content document. A file the manifest declares as XHTML but which
+// is not well-formed XML first gets its unclosed void elements closed and is
+// parsed as XML again; only if that still fails is it parsed as HTML. The
+// HTML parser is not a faithful reading of such a file: it ignores `/>` on
+// non-void elements and re-opens formatting elements across blocks, so an
+// `<a id="page_25"/>` at the top of a paragraph swallows every following
+// `<p>` until the next anchor, and positions (CFIs, other readers' locators)
+// stop matching the book's real structure. Shared by the render path
+// (`loadReplaced`) and the off-screen path (`loadDocument`) so both see the
+// same DOM.
+const parseContentDocument = (parser, str, mediaType) => {
+    let doc = parser.parseFromString(str, mediaType)
+    if (mediaType !== MIME.XHTML || !isBrokenXHTML(doc)) return { doc, mediaType }
+    const repaired = closeVoidElements(str)
+    if (repaired !== str) {
+        doc = parser.parseFromString(repaired, mediaType)
+        if (!isBrokenXHTML(doc)) return { doc, mediaType }
+    }
+    console.warn(doc.querySelector('parsererror')?.innerText ?? 'Invalid XHTML')
+    return { doc: parser.parseFromString(str, MIME.HTML), mediaType: MIME.HTML }
+}
+
 // https://www.w3.org/TR/epub-33/#sec-reserved-prefixes
 const PREFIX = {
     a11y: 'http://www.idpf.org/epub/vocab/package/a11y/#',
@@ -1018,14 +1051,10 @@ class Loader {
 
         // parse and replace in HTML
         if ([MIME.XHTML, MIME.HTML, MIME.SVG].includes(mediaType)) {
-            let doc = new DOMParser().parseFromString(str, mediaType)
-            // change to HTML if it's not valid XHTML
-            if (mediaType === MIME.XHTML && (doc.querySelector('parsererror')
-            || !doc.documentElement?.namespaceURI)) {
-                console.warn(doc.querySelector('parsererror')?.innerText ?? 'Invalid XHTML')
-                item.mediaType = MIME.HTML
-                doc = new DOMParser().parseFromString(str, item.mediaType)
-            }
+            const parsed = parseContentDocument(new DOMParser(), str, mediaType)
+            const doc = parsed.doc
+            // it's now HTML if it wasn't valid XHTML even after repair
+            item.mediaType = parsed.mediaType
             // replace hrefs in XML processing instructions
             // this is mainly for SVGs that use xml-stylesheet
             if ([MIME.XHTML, MIME.SVG].includes(item.mediaType)) {
@@ -1283,16 +1312,7 @@ ${doc.querySelector('parsererror').innerText}`)
     }
     async loadDocument(item) {
         const str = await this.loadText(item.href)
-        const doc = this.parser.parseFromString(str, item.mediaType)
-        // Same fallback as the render path in `loadReplaced`: a file the
-        // manifest declares as XHTML but which isn't well-formed XML (an
-        // unclosed `<meta charset>` is the usual culprit) parses into a
-        // `parsererror` document whose `body` is null. Callers of
-        // `createDocument` walk that body, so retry as HTML instead.
-        if (item.mediaType === MIME.XHTML
-        && (doc.querySelector('parsererror') || !doc.documentElement?.namespaceURI))
-            return this.parser.parseFromString(str, MIME.HTML)
-        return doc
+        return parseContentDocument(this.parser, str, item.mediaType).doc
     }
     getMediaOverlay() {
         return new MediaOverlay(this, this.#loadXML.bind(this))


### PR DESCRIPTION
## Summary

A file the manifest declares as `application/xhtml+xml` but which is not well-formed XML was re-parsed as `text/html`, in both `loadReplaced` (the render path) and `loadDocument` (`createDocument`). The HTML parser is not a faithful reading of such a file: it ignores `/>` on non-void elements and re-opens formatting elements across blocks. An InDesign page anchor `<a id="page_25"/>` at the top of a paragraph therefore swallowed every following `<p>` until the next anchor, and a mid-paragraph anchor split its paragraph back out to body level. CFIs then described that rewritten tree, and KOReader, whose crengine honours `/>`, could not resolve them: highlights synced from Readest landed on page 1, and KOReader's own locators landed on unrelated paragraphs in Readest (readest/readest#5271).

The usual, and often only, fault in these files is an unclosed void element such as `<meta charset="utf-8">`. `parseContentDocument` now closes those and parses as XML again; HTML remains the fallback when the file is broken beyond that. Both paths share it so the rendered and off-screen DOMs agree.

## Design notes

- The repair regex matches lowercase void tags only, respects quoted attribute values, requires a real tag boundary so `<bracket>` is not touched, and leaves tags that are already self-closed alone.
- Uppercase void tags are deliberately not closed: `<BR/>` would parse as an unknown element in XHTML instead of a line break, so those files keep taking the HTML path.
- Books this repairs render with a different DOM than before, so positions stored against the old anchor-wrapped structure will no longer resolve. That is inherent to fixing the parse.

## Verification

- readest/readest tests in `src/__tests__/foliate-epub-malformed-xhtml.test.ts`: repaired DOM keeps the paragraphs under `<body>` with empty anchors, XPointer conversion both ways on that DOM, the rendered blob from `section.load()` parses as XML with the same shape, and a file with a bare `&` still falls back to HTML.
- A crengine oracle run on the two reported books: 2946 and 1845 sampled words now convert exactly in both directions, where before all but a handful failed.
- `eslint epub.js` clean; the full readest unit suite passes with this commit pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
