### PR TITLE
fix(paginator): keep a collapsed visible range in scrolled mode so an image-only cover relocates

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -3313,6 +3313,7 @@ export class Paginator extends HTMLElement {
             // bottom of the book).
             const center = this.#renderedStart + this.size / 2
             let fallback
+            let collapsed
             for (const [index, v] of this.#sortedViews) {
                 if (!v.document) continue
                 const off = this.#getViewOffset(index)
@@ -3322,11 +3323,24 @@ export class Paginator extends HTMLElement {
                 const range = getVisibleRange(v.document,
                     this.#renderedStart - off, this.#renderedEnd - off,
                     this.#getRectMapper(v))
-                if (!range || range.collapsed) continue
-                if (center >= off && center < off + vSize) return { range, index }
+                if (!range) continue
+                const coversCenter = center >= off && center < off + vSize
+                // A section with no accepted node in view (an image-only cover
+                // whose <svg>/<img> is clipped by the viewport, a text-less
+                // background page) collapses onto <body>. Prefer any view with
+                // real content, but keep the collapsed range as a last resort:
+                // dropping it left an image-only cover with no relocate at all
+                // on open, so the host never got a location to record or sync
+                // reading progress from. Paginated mode relocates on the same
+                // collapsed range.
+                if (range.collapsed) {
+                    if (!collapsed || coversCenter) collapsed = { range, index }
+                    continue
+                }
+                if (coversCenter) return { range, index }
                 fallback ??= { range, index }
             }
-            return fallback
+            return fallback ?? collapsed
         }
         const range = getVisibleRange(targetView.document,
             this.#renderedStart - viewOffset,


### PR DESCRIPTION
## Summary

A book opened for the first time on a device in scrolled mode never emitted a `relocate` when its cover is image-only (an `<svg><image/>` or a lone `<img>`), so the host (Readest) never received a location to record or sync reading progress from. Paginated mode was unaffected.

## Root cause

`#getVisibleRange` in scrolled mode skips every view whose visible range is collapsed, a rule added to prefer the section covering the viewport centre. An image-only cover collapses onto `<body>`: its only in-view element is clipped by the viewport and the scrolled rect mapper subtracts the page margin, so the tree walk accepts no node. When no other loaded view overlaps the viewport the method returns `undefined`, `#afterScroll` bails before dispatching, and no `relocate` fires on open. The paginated branch returns the same collapsed range and relocates on `epubcfi(/6/2!/4)`.

## Fix

Keep the collapsed range as a last resort (preferring the view that covers the centre) while still favouring any view with real content. Views with text keep winning at section boundaries.

## Test

Browser regression test in the Readest repo (`src/__tests__/document/paginator-scrolled-cover-relocate.browser.test.ts`): a synthetic book whose cover is one oversized `<svg>` must relocate on `goTo({ index: 0, anchor: 0 })` in scrolled mode, and a scroll that puts the text chapter over the centre must still report the chapter with a non-collapsed range. The first case fails on `main` and passes here. Verified live on the Readest web app with a Bible EPUB (SVG cover): after the fix the cover relocates on open, the cloud pull runs, and the reader jumps to the remote position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
