### PR TITLE
fix(overlayer): keep highlight caps on the rect's own page

### DIFF
--- a/overlayer.js
+++ b/overlayer.js
@@ -3,6 +3,16 @@ const createSVGElement = tag =>
 
 let overlayerCounter = 0
 
+// The page a rect sits in. The paginator sizes the root to a single page and
+// lets the rest overflow it, so the root box tiles the pages along either
+// axis, in either direction; in scrolled mode the root is the whole document.
+const pageOf = (root, { left, top, right, bottom }) => {
+    if (!(root.width > 0 && root.height > 0)) return null
+    const x = root.left + Math.floor(((left + right) / 2 - root.left) / root.width) * root.width
+    const y = root.top + Math.floor(((top + bottom) / 2 - root.top) / root.height) * root.height
+    return { left: x, top: y, right: x + root.width, bottom: y + root.height }
+}
+
 export class Overlayer {
     #svg = createSVGElement('svg')
     #map = new Map()
@@ -118,17 +128,20 @@ export class Overlayer {
     }
     #getRects(range) {
         const zoom = this.#zoom
+        const root = this.#doc.documentElement.getBoundingClientRect()
         const rects = []
         for (const subRange of this.#splitRange(range)) {
             for (const rect of subRange.getClientRects()) {
-                rects.push({
+                const scaled = {
                     left: rect.left * zoom,
                     top: rect.top * zoom,
                     right: rect.right * zoom,
                     bottom: rect.bottom * zoom,
                     width: rect.width * zoom,
                     height: rect.height * zoom,
-                })
+                }
+                scaled.page = pageOf(root, scaled)
+                rects.push(scaled)
             }
         }
         return rects
@@ -264,7 +277,7 @@ export class Overlayer {
         g.style.opacity = 'var(--overlayer-highlight-opacity, .3)'
         g.style.mixBlendMode = 'var(--overlayer-highlight-blend-mode, normal)'
 
-        for (const [index, { left, top, height, width }] of rects.entries()) {
+        for (const [index, { left, top, height, width, page }] of rects.entries()) {
             const isFirst = index === 0
             const isLast = index === rects.length - 1
 
@@ -290,6 +303,21 @@ export class Overlayer {
                 radiusTopRight = isLast ? radius : 0
                 radiusBottomRight = isLast ? radius : 0
                 radiusBottomLeft = isFirst ? radius : 0
+            }
+
+            // The caps pad past the rects, and with the page margins and gap
+            // at zero the pages touch: the 2px after a column-wide image
+            // painted a stripe the height of the image down the edge of the
+            // next page (readest/readest#6128). Never paint past the rect's
+            // own page.
+            if (page) {
+                const right = Math.min(x + w, page.right)
+                const bottom = Math.min(y + h, page.bottom)
+                x = Math.max(x, page.left)
+                y = Math.max(y, page.top)
+                w = right - x
+                h = bottom - y
+                if (w <= 0 || h <= 0) continue
             }
 
             const rtl = Math.min(radiusTopLeft, w / 2, h / 2)


### PR DESCRIPTION
Fixes the 2px highlight stripe that readest/readest#6128 reports on the page after a highlighted image.

`Overlayer.highlight` pads the first and last rect by `radiusPadding` (2px) so the corner radius clears the glyphs. In paginated mode the column gap is the page margins plus the gap setting; Readest's mobile margin slider drives both from one value, so at its minimum adjacent pages touch and the cap after a column-wide image lands on the next page as a stripe the height of the image. A justified line that ends at the page edge leaks the same way, one line tall.

`#getRects` now tags each rect with the page tile it sits in: the paginator sizes the document root to exactly one page and lets the rest overflow it, so the root box tiles the pages along either axis in either direction, and in scrolled mode the root is the whole document. `highlight()` clamps every box to that tile and skips empty ones. Caps still reach into real margins, so nothing changes visually until pages actually touch.

Verified in Readest with a Chromium browser test (readest/readest PR to follow): with margins 0 and gap 0%, a highlight ending on a column-wide image drew its box at x 800..1602 on an 800px page before and stays within 800..1600 after; a vertical-rl heading's leading cap at y = -2 is clamped the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)